### PR TITLE
Fix previous Eye Spy advancement injection

### DIFF
--- a/src/main/java/net/teamremastered/tlc/mixin/AdvBuilderAccessor.java
+++ b/src/main/java/net/teamremastered/tlc/mixin/AdvBuilderAccessor.java
@@ -1,0 +1,11 @@
+package net.teamremastered.tlc.mixin;
+
+import net.minecraft.advancement.Advancement;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Advancement.Builder.class)
+public interface AdvBuilderAccessor {
+    @Accessor
+    String[][] getRequirements();
+}

--- a/src/main/java/net/teamremastered/tlc/mixin/ServerAdvancementLoaderMixin.java
+++ b/src/main/java/net/teamremastered/tlc/mixin/ServerAdvancementLoaderMixin.java
@@ -13,6 +13,7 @@ import net.minecraft.predicate.entity.LocationPredicate;
 import net.minecraft.server.ServerAdvancementLoader;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.gen.structure.StructureKeys;
+import net.teamremastered.tlc.registries.LCStructures;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -21,9 +22,9 @@ public abstract class ServerAdvancementLoaderMixin {
     @WrapOperation(method = "method_20723", at = @At(value = "INVOKE", target = "Lnet/minecraft/advancement/Advancement$Builder;fromJson(Lcom/google/gson/JsonObject;Lnet/minecraft/predicate/entity/AdvancementEntityPredicateDeserializer;)Lnet/minecraft/advancement/Advancement$Builder;"))
     private Advancement.Builder tlc$buildFromJsonWrapper(JsonObject obj, AdvancementEntityPredicateDeserializer predicateDeserializer, Operation<Advancement.Builder> original, @Local(argsOnly = true) Identifier id) {
         Advancement.Builder result = original.call(obj, predicateDeserializer);
-        if (id.equals(Identifier.tryParse("follow_ender_eye"))) {
+        if (id.equals(Identifier.tryParse("story/follow_ender_eye"))) {
             String s = "in_castle";
-            CriterionConditions c = TickCriterion.Conditions.createLocation(LocationPredicate.feature(StructureKeys.STRONGHOLD));
+            CriterionConditions c = TickCriterion.Conditions.createLocation(LocationPredicate.feature(RegistryKey.of(RegistryKeys.STRUCTURE, LCStructures.CASTLE_ID)));
             AdvancementCriterion criterion = new AdvancementCriterion(c);
             result.criterion(s, criterion);
             result.requirements(new String[][]{{s}});

--- a/src/main/java/net/teamremastered/tlc/mixin/ServerAdvancementLoaderMixin.java
+++ b/src/main/java/net/teamremastered/tlc/mixin/ServerAdvancementLoaderMixin.java
@@ -4,18 +4,23 @@ import com.google.gson.JsonObject;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.advancement.Advancement;
 import net.minecraft.advancement.AdvancementCriterion;
 import net.minecraft.advancement.criterion.CriterionConditions;
 import net.minecraft.advancement.criterion.TickCriterion;
 import net.minecraft.predicate.entity.AdvancementEntityPredicateDeserializer;
 import net.minecraft.predicate.entity.LocationPredicate;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.server.ServerAdvancementLoader;
 import net.minecraft.util.Identifier;
-import net.minecraft.world.gen.structure.StructureKeys;
+import net.teamremastered.tlc.TheLostCastle;
 import net.teamremastered.tlc.registries.LCStructures;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.Arrays;
 
 @Mixin(ServerAdvancementLoader.class)
 public abstract class ServerAdvancementLoaderMixin {
@@ -27,7 +32,13 @@ public abstract class ServerAdvancementLoaderMixin {
             CriterionConditions c = TickCriterion.Conditions.createLocation(LocationPredicate.feature(RegistryKey.of(RegistryKeys.STRUCTURE, LCStructures.CASTLE_ID)));
             AdvancementCriterion criterion = new AdvancementCriterion(c);
             result.criterion(s, criterion);
-            result.requirements(new String[][]{{s}});
+            String[][] req = ((AdvBuilderAccessor)result).getRequirements();
+            req = Arrays.copyOf(req, req.length+1);
+            req[req.length-1] = new String[]{s};
+            result.requirements(req);
+            if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
+                TheLostCastle.LOGGER.info("[The Lost Castle/debug] Eye Spy advancement modified to: {}", result.toJson());
+            }
         }
         return result;
     }

--- a/src/main/java/net/teamremastered/tlc/registries/LCStructures.java
+++ b/src/main/java/net/teamremastered/tlc/registries/LCStructures.java
@@ -10,6 +10,7 @@ import net.teamremastered.tlc.structures.LostCastle;
 public class LCStructures {
 
     public static StructureType<LostCastle> LOST_CASTLE;
+    public static final Identifier CASTLE_ID = new Identifier(TheLostCastle.MODID, "lost_castle");
 
     /**
      * Registers the structure itself and sets what its path is. In this case, the
@@ -19,7 +20,7 @@ public class LCStructures {
      * use them too directly from the registries. It's great for mod/datapacks compatibility.
      */
     public static void init() {
-        LOST_CASTLE = Registry.register(Registries.STRUCTURE_TYPE, new Identifier(TheLostCastle.MODID, "lost_castle"), () -> LostCastle.CODEC);
+        LOST_CASTLE = Registry.register(Registries.STRUCTURE_TYPE, CASTLE_ID, () -> LostCastle.CODEC);
     }
 
 }

--- a/src/main/resources/tlc.mixins.json
+++ b/src/main/resources/tlc.mixins.json
@@ -4,6 +4,7 @@
   "package": "net.teamremastered.tlc.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "AdvBuilderAccessor",
     "ServerAdvancementLoaderMixin"
   ],
   "client": [


### PR DESCRIPTION
* target the right advancement
  * from `minecraft:follow_ender_eye` to `minecraft:story/follow_ender_eye`
* target the right structure
  * was set to stronghold
* don't overwrite the whole requirements array
  * required adding an accessor to fetch the existing array
* added a small debug line to check for proper advancement modification (only triggered in dev env)